### PR TITLE
changed the type of coord so it can work with new Pydra typing

### DIFF
--- a/pydra/tasks/mrtrix3/utils.py
+++ b/pydra/tasks/mrtrix3/utils.py
@@ -35,7 +35,7 @@ MRConvertInputSpec = SpecInfo(
         (
             "coord",
             attr.ib(
-                type=ty.List[float],
+                type=ty.Tuple[int, ty.Union[int, str]],
                 metadata={
                     "sep": " ",
                     "argstr": "-coord",


### PR DESCRIPTION
changed the type of the `coord` input field from `ty.List[float]` to `ty.Tuple[int, ty.Union[int, str]]`, so it can work with the typing system in nipype/pydra#662