### PR TITLE
made config option optional

### DIFF
--- a/pydra/tasks/mrtrix3/manual/mrcalc.py
+++ b/pydra/tasks/mrtrix3/manual/mrcalc.py
@@ -62,7 +62,7 @@ class MrCalcOp(Enum):
 
 
 def operations_formatter(
-    operations: ty.List[ty.Tuple[ty.List[ty.Union[ImageIn, float]], MrCalcOp]]
+    operations: ty.List[ty.Tuple[ty.List[ty.Union[ImageIn, float]], MrCalcOp]],
 ):
     return " ".join(
         [
@@ -272,7 +272,7 @@ class MrCalc(shell.Task["MrCalc.Outputs"]):
         default=None,
     )
 
-    config: MultiInputObj[tuple[str, str]] = shell.arg(
+    config: MultiInputObj[tuple[str, str]] | None = shell.arg(
         argstr="-config",
         help="""temporarily set the value of an MRtrix config file entry.""",
     )

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_3dautomask.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_3dautomask.py
@@ -154,7 +154,7 @@ class Dwi2Mask_3dautomask(shell.Task["Dwi2Mask_3dautomask.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_ants.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_ants.py
@@ -104,7 +104,7 @@ class Dwi2Mask_Ants(shell.Task["Dwi2Mask_Ants.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_b02template.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_b02template.py
@@ -127,7 +127,7 @@ class Dwi2Mask_B02template(shell.Task["Dwi2Mask_B02template.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_consensus.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_consensus.py
@@ -112,7 +112,7 @@ class Dwi2Mask_Consensus(shell.Task["Dwi2Mask_Consensus.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_fslbet.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_fslbet.py
@@ -124,7 +124,7 @@ class Dwi2Mask_Fslbet(shell.Task["Dwi2Mask_Fslbet.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_hdbet.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_hdbet.py
@@ -104,7 +104,7 @@ class Dwi2Mask_Hdbet(shell.Task["Dwi2Mask_Hdbet.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_legacy.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_legacy.py
@@ -97,7 +97,7 @@ class Dwi2Mask_Legacy(shell.Task["Dwi2Mask_Legacy.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_mean.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_mean.py
@@ -107,7 +107,7 @@ class Dwi2Mask_Mean(shell.Task["Dwi2Mask_Mean.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_mtnorm.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_mtnorm.py
@@ -116,7 +116,7 @@ class Dwi2Mask_Mtnorm(shell.Task["Dwi2Mask_Mtnorm.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_synthstrip.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_synthstrip.py
@@ -119,7 +119,7 @@ class Dwi2Mask_Synthstrip(shell.Task["Dwi2Mask_Synthstrip.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2mask_trace.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2mask_trace.py
@@ -117,7 +117,7 @@ class Dwi2Mask_Trace(shell.Task["Dwi2Mask_Trace.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2response_dhollander.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2response_dhollander.py
@@ -147,7 +147,7 @@ class Dwi2Response_Dhollander(shell.Task["Dwi2Response_Dhollander.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2response_fa.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2response_fa.py
@@ -129,7 +129,7 @@ class Dwi2Response_Fa(shell.Task["Dwi2Response_Fa.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2response_manual.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2response_manual.py
@@ -122,7 +122,7 @@ class Dwi2Response_Manual(shell.Task["Dwi2Response_Manual.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2response_msmt_5tt.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2response_msmt_5tt.py
@@ -145,7 +145,7 @@ class Dwi2Response_Msmt_5tt(shell.Task["Dwi2Response_Msmt_5tt.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2response_tax.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2response_tax.py
@@ -129,7 +129,7 @@ class Dwi2Response_Tax(shell.Task["Dwi2Response_Tax.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwi2response_tournier.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwi2response_tournier.py
@@ -134,7 +134,7 @@ class Dwi2Response_Tournier(shell.Task["Dwi2Response_Tournier.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwibiascorrect_ants.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwibiascorrect_ants.py
@@ -119,7 +119,7 @@ class DwiBiascorrect_Ants(shell.Task["DwiBiascorrect_Ants.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwibiascorrect_fsl.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwibiascorrect_fsl.py
@@ -106,7 +106,7 @@ class DwiBiascorrect_Fsl(shell.Task["DwiBiascorrect_Fsl.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwibiascorrect_mtnorm.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwibiascorrect_mtnorm.py
@@ -113,7 +113,7 @@ class DwiBiascorrect_Mtnorm(shell.Task["DwiBiascorrect_Mtnorm.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwibiasnormmask.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwibiasnormmask.py
@@ -143,7 +143,7 @@ class DwiBiasnormmask(shell.Task["DwiBiasnormmask.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwicat.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwicat.py
@@ -87,7 +87,7 @@ class DwiCat(shell.Task["DwiCat.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwifslpreproc.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwifslpreproc.py
@@ -192,7 +192,7 @@ class DwiFslpreproc(shell.Task["DwiFslpreproc.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwigradcheck.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwigradcheck.py
@@ -105,7 +105,7 @@ class DwiGradcheck(shell.Task["DwiGradcheck.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwinormalise_group.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwinormalise_group.py
@@ -92,7 +92,7 @@ class DwiNormalise_Group(shell.Task["DwiNormalise_Group.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwinormalise_manual.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwinormalise_manual.py
@@ -102,7 +102,7 @@ class DwiNormalise_Manual(shell.Task["DwiNormalise_Manual.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwinormalise_mtnorm.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwinormalise_mtnorm.py
@@ -120,7 +120,7 @@ class DwiNormalise_Mtnorm(shell.Task["DwiNormalise_Mtnorm.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/dwishellmath.py
+++ b/pydra/tasks/mrtrix3/v3_1/dwishellmath.py
@@ -116,7 +116,7 @@ class DwiShellmath(shell.Task["DwiShellmath.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/fivettgen_deep_atropos.py
+++ b/pydra/tasks/mrtrix3/v3_1/fivettgen_deep_atropos.py
@@ -101,7 +101,7 @@ class FivettGen_Deep_atropos(shell.Task["FivettGen_Deep_atropos.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/fivettgen_freesurfer.py
+++ b/pydra/tasks/mrtrix3/v3_1/fivettgen_freesurfer.py
@@ -104,7 +104,7 @@ class FivettGen_Freesurfer(shell.Task["FivettGen_Freesurfer.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/fivettgen_fsl.py
+++ b/pydra/tasks/mrtrix3/v3_1/fivettgen_fsl.py
@@ -122,7 +122,7 @@ class FivettGen_Fsl(shell.Task["FivettGen_Fsl.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/fivettgen_gif.py
+++ b/pydra/tasks/mrtrix3/v3_1/fivettgen_gif.py
@@ -99,7 +99,7 @@ class FivettGen_Gif(shell.Task["FivettGen_Gif.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/fivettgen_hsvs.py
+++ b/pydra/tasks/mrtrix3/v3_1/fivettgen_hsvs.py
@@ -117,7 +117,7 @@ class FivettGen_Hsvs(shell.Task["FivettGen_Hsvs.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/labelsgmfirst.py
+++ b/pydra/tasks/mrtrix3/v3_1/labelsgmfirst.py
@@ -103,7 +103,7 @@ class LabelSgmfirst(shell.Task["LabelSgmfirst.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/mask2glass.py
+++ b/pydra/tasks/mrtrix3/v3_1/mask2glass.py
@@ -87,7 +87,7 @@ class Mask2Glass(shell.Task["Mask2Glass.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/mrtrix_cleanup.py
+++ b/pydra/tasks/mrtrix3/v3_1/mrtrix_cleanup.py
@@ -87,7 +87,7 @@ class MrTrix_Cleanup(shell.Task["MrTrix_Cleanup.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/population_template.py
+++ b/pydra/tasks/mrtrix3/v3_1/population_template.py
@@ -250,7 +250,7 @@ class PopulationTemplate(shell.Task["PopulationTemplate.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,

--- a/pydra/tasks/mrtrix3/v3_1/responsemean.py
+++ b/pydra/tasks/mrtrix3/v3_1/responsemean.py
@@ -87,7 +87,7 @@ class ResponseMean(shell.Task["ResponseMean.Outputs"]):
         argstr="-nthreads",
         default=None,
     )
-    config: MultiInputObj[MultiInputObj] = shell.arg(
+    config: MultiInputObj[MultiInputObj] | None = shell.arg(
         help="temporarily set the value of an MRtrix config file entry.",
         argstr="-config",
         default=None,


### PR DESCRIPTION
the generic "config" option was showing up as mandatory for some tasks, manually changed to optional by appending `| None`